### PR TITLE
Get all pl-fshack-infant feeds on results page

### DIFF
--- a/src/api/fnndsc__chrisapi.d.ts
+++ b/src/api/fnndsc__chrisapi.d.ts
@@ -1299,7 +1299,7 @@ declare module "@fnndsc/chrisapi" {
      *
      * @type {boolean}
      */
-    get isEmpty();
+    get isEmpty(): boolean;
 
     /**
      * Return true if the list resource object has a next list page in the
@@ -1307,7 +1307,7 @@ declare module "@fnndsc/chrisapi" {
      *
      * @type {boolean}
      */
-    get hasNextPage()
+    get hasNextPage(): boolean;
 
     /**
      * Return true if the list resource object has a previous list page in the

--- a/src/shared/Constants.ts
+++ b/src/shared/Constants.ts
@@ -2,7 +2,7 @@ export const dircopyPluginName = "pl-dircopy";
 export const med2ImgPluginName = "pl-med2img";
 export const infantFSPluginName = "pl-fshack-infant";
 
-export const feedPageParameter = "id";
+export const feedPageParameter = "feedId";
 
 export const statsWithTableStructure = [
 	"aseg.stats",


### PR DESCRIPTION
# Changes made:
## Revised logic that gets feeds
- Can now get all feeds
- Renamed FeedPage's React Router parameter constant to be more fitting
- Changed spacing
- Added return types to getter methods in ChRIS API types file

## Before
![image](https://user-images.githubusercontent.com/33106214/119065362-5c0f8800-b9ab-11eb-977f-1641f5c668e1.png)

## After
![image](https://user-images.githubusercontent.com/33106214/119065338-4d28d580-b9ab-11eb-98c0-f5e504f30222.png)
