### PR TITLE
Revise display of workflow results

### DIFF
--- a/src/components/FeedPage.tsx
+++ b/src/components/FeedPage.tsx
@@ -3,6 +3,7 @@ import { Container, Table, ListGroup, Tab, Row, Col } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 import ClientSingleton from "../api/ClientSingleton";
 import Client, {
+	Feed,
 	FeedFile,
 	PluginInstance,
 	PluginInstanceFileList,
@@ -33,77 +34,60 @@ interface TableStructure {
 function FeedPage(): JSX.Element {
 	let params = useParams<Parameters>();
 	const feedId = params[feedPageParameter];
-	const [fshackPlugin, setFshackPlugin] = useState<PluginInstance>(null);
-	const [fshackFiles, setFshackFiles] = useState<File[]>(null);
-	const [med2ImgPlugin, setMed2ImgPlugin] = useState<PluginInstance>(null);
-	const [med2ImgFiles, setMed2ImgFiles] = useState<File[]>(null);
+	const [instances, setInstances] = useState<PluginInstance[]>([]);
+	const [files, setFiles] = useState<File[][]>([]);
 
 	useEffect(() => {
-		getPluginAndFiles(
-			feedId,
-			infantFSPluginName,
-			setFshackPlugin,
-			setFshackFiles
-		);
-		getPluginAndFiles(
-			feedId,
-			med2ImgPluginName,
-			setMed2ImgPlugin,
-			setMed2ImgFiles
-		);
+		setPluginAndFiles(feedId, setInstances, setFiles);
 	}, []);
 
 	return (
 		<Container className="py-4">
 			<h3>Feed Page</h3>
-			<h4>Infant FS plugin results</h4>
-			{getPluginContent(fshackPlugin)}
-			{getFilesContents(fshackFiles, infantFSPluginName)}
-
-			<h4>Medical image plugin results</h4>
-			{getPluginContent(med2ImgPlugin)}
-
-			{/* I can get rid of this once we have pl-multipass set up */}
-			{getFilesContents(med2ImgFiles, med2ImgPluginName)}
+			{instances.map((instance, index) => {
+				const infoDisplay = renderPluginInfo(instance);
+				const pluginFiles: File[] = files[index];
+				const pluginName: string = instance.data.plugin_name;
+				const filesDisplay = renderPluginFiles(pluginFiles, pluginName);
+				return (
+					<Row>
+						<h4>{pluginName} results</h4>
+						{infoDisplay}
+						{filesDisplay}
+					</Row>
+				);
+			})}
 		</Container>
 	);
 }
 
-async function getPluginAndFiles(
+async function setPluginAndFiles(
 	feedId: string,
-	pluginName: string,
-	pluginSetter: (value: React.SetStateAction<PluginInstance>) => void,
-	filesSetter: (value: React.SetStateAction<File[]>) => void
+	instancesSetter: (value: React.SetStateAction<PluginInstance[]>) => void,
+	filesSetter: (value: React.SetStateAction<File[][]>) => void
 ): Promise<void> {
 	const client = await ClientSingleton.getInstance();
-	const plugin: PluginInstance = await getPlugin(client, feedId, pluginName);
-	pluginSetter(plugin);
+	const id = parseInt(feedId);
+	const feed = await client.getFeed(id);
 
-	const feedFiles: FeedFile[] = await getFeedFiles(plugin);
-	const files: File[] = await getFiles(feedFiles);
+	const instances: PluginInstance[] = (
+		await feed.getPluginInstances()
+	).getItems();
+	const files: File[][] = [];
+
+	for (let instance of instances) {
+		const instanceFeedFiles = await getFeedFiles(instance);
+		const instanceFiles = await getFiles(instanceFeedFiles);
+		files.push(instanceFiles);
+	}
+
+	instancesSetter(instances);
 	filesSetter(files);
 }
 
-async function getPlugin(
-	client: Client,
-	feedId: string,
-	pluginName: string
-): Promise<PluginInstance> {
-	const pluginInstance = await client.getPluginInstances({
-		limit: 25,
-		offset: 0,
-		plugin_name: pluginName,
-		feed_id: feedId,
-	});
-
-	const plugin: PluginInstance = pluginInstance.getItems()[0];
-
-	return plugin;
-}
-
-async function getFeedFiles(plugin: PluginInstance): Promise<FeedFile[]> {
-	const fileParams = { limit: 200, offset: 0 };
-	let pluginInstanceFiles: PluginInstanceFileList = await plugin.getFiles(
+async function getFeedFiles(instance: PluginInstance): Promise<FeedFile[]> {
+	const fileParams = { limit: 25, offset: 0 };
+	let pluginInstanceFiles: PluginInstanceFileList = await instance.getFiles(
 		fileParams
 	);
 	let feedFiles: FeedFile[] = pluginInstanceFiles.getItems();
@@ -111,7 +95,7 @@ async function getFeedFiles(plugin: PluginInstance): Promise<FeedFile[]> {
 	while (pluginInstanceFiles.hasNextPage) {
 		try {
 			fileParams.offset += fileParams.limit;
-			pluginInstanceFiles = await plugin.getFiles(fileParams);
+			pluginInstanceFiles = await instance.getFiles(fileParams);
 			feedFiles = feedFiles.concat(pluginInstanceFiles.getItems());
 		} catch (error) {
 			throw new Error("Error while paginating files");
@@ -122,8 +106,8 @@ async function getFeedFiles(plugin: PluginInstance): Promise<FeedFile[]> {
 	return feedFiles;
 }
 
-function isStatsOrPng(file: FeedFile): boolean {
-	const { fname } = file.data;
+function isStatsOrPng(feedFile: FeedFile): boolean {
+	const { fname } = feedFile.data;
 	return fname.endsWith("stats") || fname.endsWith("png");
 }
 
@@ -145,9 +129,9 @@ async function getFiles(feedFiles: FeedFile[]): Promise<File[]> {
 	return files;
 }
 
-function getPluginContent(plugin: PluginInstance): JSX.Element {
-	if (plugin && plugin.data) {
-		const { data } = plugin;
+function renderPluginInfo(instance: PluginInstance): JSX.Element {
+	if (instance && instance.data) {
+		const { data } = instance;
 		const keys = Object.keys(keyToTextMap);
 
 		return (
@@ -165,7 +149,7 @@ function getPluginContent(plugin: PluginInstance): JSX.Element {
 					<tr>
 						{keys.map((key, index) => (
 							<td key={index}>
-								{plugin.data[key as keyof typeof data]}
+								{instance.data[key as keyof typeof data]}
 							</td>
 						))}
 					</tr>
@@ -175,32 +159,29 @@ function getPluginContent(plugin: PluginInstance): JSX.Element {
 	}
 }
 
-function getFilesContents(files: File[], pluginName: string): JSX.Element {
-	if (files) {
-		const prefix = files[0].fname.endsWith("stats")
+function renderPluginFiles(files: File[], pluginName: string): JSX.Element {
+	if (files && files.length !== 0) {
+		const first = files[0];
+		const prefix = first.fname.endsWith("stats")
 			? infantFSPluginName
-			: files[0].fname.endsWith("png")
+			: first.fname.endsWith("png")
 			? med2ImgPluginName
 			: "link";
 
 		const listGroup = (
 			<ListGroup defaultActiveKey={`#${prefix}0`}>
-				{files.map(getListGroupItem(prefix))}
+				{files.map(renderListGroupItem(prefix))}
 			</ListGroup>
 		);
 
 		const tabContent = (
-			<Tab.Content>
-				{files.map(getTabPane(handlePng, handleStats, prefix))}
-			</Tab.Content>
+			<Tab.Content>{files.map(renderTabPane(prefix))}</Tab.Content>
 		);
 
 		return (
 			<Tab.Container id={`list-group-tabs-${pluginName}`}>
-				<Row>
-					<Col md={2}>{listGroup} </Col>
-					<Col md={10}>{tabContent}</Col>
-				</Row>
+				<Col md={3}>{listGroup} </Col>
+				<Col md={9}>{tabContent}</Col>
 			</Tab.Container>
 		);
 	}
@@ -210,43 +191,29 @@ function handleStats(fname: string, content: string): JSX.Element {
 	let { header, body }: TableStructure = getTableStructure(fname, content);
 
 	return (
-		<>
-			<p>
-				<b style={{ color: "red" }}>{`STATS: `}</b>
-				{fname}
-			</p>
-			<Table responsive size="sm">
-				<thead>
+		<Table responsive size="sm">
+			<thead>
+				<tr>
+					{header.map((col) => (
+						<th>{col}</th>
+					))}
+				</tr>
+			</thead>
+			<tbody>
+				{body.map((row) => (
 					<tr>
-						{header.map((col) => (
-							<th>{col}</th>
+						{row.map((col) => (
+							<td>{col}</td>
 						))}
 					</tr>
-				</thead>
-				<tbody>
-					{body.map((row) => (
-						<tr>
-							{row.map((col) => (
-								<td>{col}</td>
-							))}
-						</tr>
-					))}
-				</tbody>
-			</Table>
-		</>
+				))}
+			</tbody>
+		</Table>
 	);
 }
 
 function handlePng(fname: string, content: string): JSX.Element {
-	return (
-		<>
-			<p>
-				<b style={{ color: "red" }}>{`PNG: `}</b>
-				{fname}
-			</p>
-			<img src={content} />
-		</>
-	);
+	return <img src={content} />;
 }
 
 function getTableStructure(fname: string, content: string): TableStructure {
@@ -278,24 +245,25 @@ function getTableStructure(fname: string, content: string): TableStructure {
 	return { header, body };
 }
 
-function getListGroupItem(
+function renderListGroupItem(
 	prefix: string
-): (value: File, index: number, array: File[]) => JSX.Element {
-	return (_, index) => (
-		<ListGroup.Item action href={`#${prefix}${index}`}>
-			File {index}
-		</ListGroup.Item>
-	);
+): (value: File, index: number) => JSX.Element {
+	return (value, index) => {
+		return (
+			<ListGroup.Item action href={`#${prefix}${index}`}>
+				{getShortFilename(value.fname)}
+			</ListGroup.Item>
+		);
+	};
 }
 
-function getTabPane(
-	handlePng: (fname: string, content: string) => JSX.Element,
-	handleStats: (fname: string, content: string) => JSX.Element,
+function renderTabPane(
 	prefix: string
 ): (value: File, index: number, array: File[]) => JSX.Element {
 	return (file, index) => {
 		const { fname, content } = file;
-		let paneContent = <p>{fname}</p>;
+		let paneContent = null;
+		const filenameContent = renderFilename(fname);
 
 		if (fname.endsWith("png")) {
 			paneContent = handlePng(fname, content);
@@ -306,9 +274,25 @@ function getTabPane(
 			paneContent = handleStats(fname, content);
 		}
 		return (
-			<Tab.Pane eventKey={`#${prefix}${index}`}>{paneContent}</Tab.Pane>
+			<Tab.Pane eventKey={`#${prefix}${index}`}>
+				{filenameContent}
+				{paneContent}
+			</Tab.Pane>
 		);
 	};
+}
+
+function renderFilename(fname: string) {
+	return (
+		<p>
+			<b>{`Filename: `}</b>
+			{getShortFilename(fname)}
+		</p>
+	);
+}
+
+function getShortFilename(fname: string): string {
+	return fname.split("/").pop();
 }
 
 export default FeedPage;


### PR DESCRIPTION
Changes made:
- Display all plugins and their corresponding files arbitrarily given their feed id
- Replace tab container text "File 1" with corresponding file name 
- Code refactoring on function definitions